### PR TITLE
[Dockerfile]: Delete caches to reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:18.04
-RUN apt update
-RUN apt install -y git wget
+RUN apt update && \
+    apt install -y git wget && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG RELEASE_TAG
 
 WORKDIR /home/
 
-# Downloading the latest VSC Server release
-RUN wget https://github.com/gitpod-io/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-x64.tar.gz
-
-# Extracting the release archive
-RUN tar -xzf ${RELEASE_TAG}-linux-x64.tar.gz
+# Downloading the latest VSC Server release and extracting the release archive
+RUN wget https://github.com/gitpod-io/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-x64.tar.gz && \
+    tar -xzf ${RELEASE_TAG}-linux-x64.tar.gz && \
+    rm -f ${RELEASE_TAG}-linux-x64.tar.gz
 
 # Creating the user and usergroup
 RUN adduser vscode-server && \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Since there are unnecessary caches in the container image that have not been deleted and the image size is increasing, delete them to reduce the image size.

As a result, the image size has been reduced from 800MB to 688MB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

None.

## How to test
<!-- Provide steps to test this PR -->

Compare the size of the image built from this Dockerfile with the latest image on DockerHub.

```shell
docker build . --build-arg RELEASE_TAG=openvscode-server-v1.60.2 -t testimage
```

```shell
docker pull gitpod/openvscode-server:latest@sha256:56c4d271800d117af2f32c4edf3cf674821803be79ca8d64f650eb40ade44abe
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
