### PR TITLE
Add LANG and LC_ALL environment vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ USER $USERNAME
 
 WORKDIR /home/workspace/
 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 ENV HOME=/home/workspace
 ENV EDITOR=code
 ENV VISUAL=code


### PR DESCRIPTION
Because Ubuntu 18 doesn't set LANG an LC_ALL by default, some
tools like PIP for Python don't work as expected[1].
Set it by default to C.UTF-8 to prevent failures.

[1] https://github.com/pypa/pip/issues/10219

## Description
<!-- Describe your changes in detail -->
It sets LANG and LC_ALL environment variables in Dockerfile by default.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/pypa/pip/issues/10219

## How to test
<!-- Provide steps to test this PR -->
`docker build -t test --build-arg RELEASE_TAG=openvscode-server-v1.60.2 .`


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
