### PR TITLE
Update ubuntu base image to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG RELEASE_TAG
 


### PR DESCRIPTION
## Description
Update the base image from ubuntu:18.04 to ubuntu:20.04

Note sure if you're accepting external contributions or actually need/want to upgrade (there might be a reason why you're using Ubuntu 18.04 as a base).

However this makes it handy when extending the image (I wanted to have the latest zsh version support in my vscode environment for my particular use case).

This is awesome btw!

## Documentation

No doco update required.
