### PR TITLE
Add `arm64` and `armhf` builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,5 +49,7 @@ jobs:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64
-          build-args: RELEASE_TAG=${{ github.event.inputs.release_tag }}
+          build-args: |
+            RELEASE_TAG=${{ github.event.inputs.release_tag }}
+            RELEASE_ORG=${{ github.repository_owner }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,13 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       
-      - name: Set Version and Quality
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Set server version
         run: |
           echo "VERSION=$(echo ${{ github.event.inputs.release_tag }} | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')" >> $GITHUB_ENV        
           quality=$([[ ${{ github.event.inputs.release_tag }} =~ insiders ]] && echo "insiders" || echo "stable")
@@ -38,9 +44,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_TAG=${{ github.event.inputs.release_tag }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,10 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm/v7
           build-args: |
             RELEASE_TAG=${{ github.event.inputs.release_tag }}
             RELEASE_ORG=${{ github.repository_owner }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       
-      - name: Set server version
+      - name: Set Version and Quality
         run: |
           echo "VERSION=$(echo ${{ github.event.inputs.release_tag }} | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p')" >> $GITHUB_ENV        
           quality=$([[ ${{ github.event.inputs.release_tag }} =~ insiders ]] && echo "insiders" || echo "stable")
@@ -48,7 +48,7 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             RELEASE_TAG=${{ github.event.inputs.release_tag }}
             RELEASE_ORG=${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
           ./resources/server/test/test-web-integration.sh --browser chromium
 
       - name: Run smoke tests
+        # Smoke tests requires a runner with the same architecture as the built vscode
+        if: matrix.arch == 'x64'
         working-directory: ./openvscode-server
         run: |
           set -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
         # os: [ubuntu-18.04, macos-11, windows-latest]
         # support only ubuntu for now
         os: [ubuntu-18.04]
-        arch: [x64, arm64]
+        arch: [x64, arm64, armhf]
     runs-on: ${{ matrix.os }}
-    name: Build on ${{ matrix.os }} ${{ matrix.arch }}
+    name: Build on ${{ matrix.os }}/${{ matrix.arch }}
     if: github.event.inputs.commit || github.event.workflow_run.conclusion == 'success'
     steps:  
         # Get the release commit from the Insiders workflow
@@ -290,7 +290,7 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           build-args: |
             RELEASE_TAG=${{ env.RELEASE_TAG }}
             RELEASE_ORG=${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-18.04]
         arch: [x64, arm64]
     runs-on: ${{ matrix.os }}
-    name: Build on ${{ matrix.os }}      
+    name: Build on ${{ matrix.os }} ${{ matrix.arch }}
     if: github.event.inputs.commit || github.event.workflow_run.conclusion == 'success'
     steps:  
         # Get the release commit from the Insiders workflow
@@ -47,7 +47,7 @@ jobs:
       
       - uses: actions/checkout@v2
         with:
-          repository: gitpod-io/openvscode-server
+          repository: ${{ github.repository_owner }}/openvscode-server
           ref: ${{ env.RELEASE_COMMIT }}
           path: openvscode-server
           token: ${{ secrets.VSCODE_GITHUB_TOKEN }}
@@ -199,7 +199,7 @@ jobs:
         if: env.QUALITY == 'stable'
         uses: softprops/action-gh-release@v1
         with:
-          repository: gitpod-io/openvscode-server
+          repository: ${{ github.repository_owner }}/openvscode-server
           target_commitish: ${{ env.RELEASE_COMMIT }}
           body: OpenVSCode Server v${{ env.VERSION }}
           tag_name: openvscode-server-v${{ env.VERSION }}
@@ -212,7 +212,7 @@ jobs:
         if: env.QUALITY == 'insiders'
         uses: dev-drprasad/delete-older-releases@v0.2.0
         with:
-          repo: gitpod-io/openvscode-server
+          repo: ${{ github.repository_owner }}/openvscode-server
           keep_latest: 0
           delete_tags: true
           delete_tag_pattern: openvscode-server-insiders
@@ -225,7 +225,7 @@ jobs:
         if: env.QUALITY == 'insiders'
         uses: softprops/action-gh-release@v1
         with:
-          repository: gitpod-io/openvscode-server
+          repository: ${{ github.repository_owner }}/openvscode-server
           target_commitish: ${{ env.RELEASE_COMMIT }}
           body: OpenVSCode Server Insiders v${{ env.VERSION }}
           tag_name: openvscode-server-insiders-v${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
           yarn --cwd test/integration/browser compile
 
       - name: Run integration tests
+        if: matrix.arch == 'x64'
         working-directory: ./openvscode-server
         run: |
           set -e
@@ -121,7 +122,6 @@ jobs:
           ./resources/server/test/test-web-integration.sh --browser chromium
 
       - name: Run smoke tests
-        # Smoke tests requires a runner with the same architecture as the built vscode
         if: matrix.arch == 'x64'
         working-directory: ./openvscode-server
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,12 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Download Linux artifact
         uses: actions/download-artifact@v2
         with:
@@ -283,6 +289,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
           build-args: RELEASE_TAG=${{ env.RELEASE_TAG }}
           tags: ${{ steps.meta.outputs.tags }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,10 @@ jobs:
         with:
           push: true
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm/v7
           build-args: |
             RELEASE_TAG=${{ env.RELEASE_TAG }}
             RELEASE_ORG=${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         # os: [ubuntu-18.04, macos-11, windows-latest]
         # support only ubuntu for now
         os: [ubuntu-18.04]
+        arch: [x64, arm64]
     runs-on: ${{ matrix.os }}
     name: Build on ${{ matrix.os }}      
     if: github.event.inputs.commit || github.event.workflow_run.conclusion == 'success'
@@ -98,7 +99,7 @@ jobs:
       
       - name: Prepare for distribution
         working-directory: ./openvscode-server
-        run: yarn gulp vscode-reh-web-linux-x64-min
+        run: yarn gulp vscode-reh-web-linux-${{ matrix.arch }}-min
       
       - name: Download playwright
         working-directory: ./openvscode-server
@@ -116,14 +117,14 @@ jobs:
         working-directory: ./openvscode-server
         run: |
           set -e
-          VSCODE_REMOTE_SERVER_PATH="$GITHUB_WORKSPACE/vscode-reh-web-linux-x64" \
+          VSCODE_REMOTE_SERVER_PATH="$GITHUB_WORKSPACE/vscode-reh-web-linux-${{ matrix.arch }}" \
           ./resources/server/test/test-web-integration.sh --browser chromium
 
       - name: Run smoke tests
         working-directory: ./openvscode-server
         run: |
           set -e
-          VSCODE_REMOTE_SERVER_PATH="$GITHUB_WORKSPACE/vscode-reh-web-linux-x64" \
+          VSCODE_REMOTE_SERVER_PATH="$GITHUB_WORKSPACE/vscode-reh-web-linux-${{ matrix.arch }}" \
           yarn smoketest --web --headless --electronArgs="--disable-dev-shm-usage --use-gl=swiftshader"
       
       - name: Determine archive filename
@@ -144,19 +145,19 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           chcp 65001
-          echo ("ARCHIVE_NAME=openvscode-server-v" + $(node -p -e "require('./openvscode-server/package.json').version")+"-"+ $("${{ runner.os }}".tolower())+"-x64") >> $env:GITHUB_ENV
-          echo ("ARCHIVE_FULL_NAME=openvscode-server-v" + $(node -p -e "require('./openvscode-server/package.json').version")+"-"+ $("${{ runner.os }}".tolower())+"-x64.${{ steps.archive.outputs.value }}") >> $env:GITHUB_ENV
+          echo ("ARCHIVE_NAME=openvscode-server-v" + $(node -p -e "require('./openvscode-server/package.json').version")+"-"+ $("${{ runner.os }}".tolower())+"-${{ matrix.arch }}") >> $env:GITHUB_ENV
+          echo ("ARCHIVE_FULL_NAME=openvscode-server-v" + $(node -p -e "require('./openvscode-server/package.json').version")+"-"+ $("${{ runner.os }}".tolower())+"-${{ matrix.arch }}.${{ steps.archive.outputs.value }}") >> $env:GITHUB_ENV
       - name: Set archive file name
         run: |
           os_name=$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')
           quality_name=$([ "$QUALITY" == "insiders" ] && echo "-insiders" || echo "")
-          name="openvscode-server${quality_name}-v${VERSION}-${os_name}-x64"
+          name="openvscode-server${quality_name}-v${VERSION}-${os_name}-${{ matrix.arch }}"
           echo "ARCHIVE_NAME=$name" >> $GITHUB_ENV
           echo "ARCHIVE_FULL_NAME=$name.$EXTENSION" >> $GITHUB_ENV
       
       - name: Rename the bundle file
         run: |
-          mv vscode-reh-web-linux-x64/ ${{ env.ARCHIVE_NAME }}/
+          mv vscode-reh-web-linux-${{ matrix.arch }}/ ${{ env.ARCHIVE_NAME }}/
       
       - name: Bundle tarfile
         if: runner.os != 'Windows'
@@ -170,7 +171,7 @@ jobs:
       - name: Archive sanity check
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ runner.os }}-x64
+          name: ${{ runner.os }}-${{ matrix.arch }}
           path: ${{ env.ARCHIVE_FULL_NAME }}
 
       - name: Slack Notification

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,9 @@ jobs:
           push: true
           context: .
           platforms: linux/amd64,linux/arm64
-          build-args: RELEASE_TAG=${{ env.RELEASE_TAG }}
+          build-args: |
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
+            RELEASE_ORG=${{ github.repository_owner }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Slack Notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN if [ -z "${RELEASE_TAG}" ]; then \
         arch="x64"; \
     elif [ "${arch}" = "aarch64" ]; then \
         arch="arm64"; \
+    elif [ "${arch}" = "armv7l" ]; then \
+        arch="armhf"; \
     fi && \
     wget https://github.com/${RELEASE_ORG}/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-${arch}.tar.gz && \
     tar -xzf ${RELEASE_TAG}-linux-${arch}.tar.gz && \


### PR DESCRIPTION
|Device|Architecture|
|-|-|
|Rasberry Pi OS| `armhf` (ARM 32-bit) | 
|Raspberry Pi (other OSes like HassOS)| `arm64` |
| Apple M1 | `arm64` |

Including docker images.

Closes https://github.com/gitpod-io/openvscode-server/issues/36