### PR TITLE
Update Docker Image to Use Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt update && \
     apt install -y git wget sudo && \


### PR DESCRIPTION
I've been testing and using OpenVSCode Server in a Docker container using Ubuntu 20.04 without any issues since OpenVSCode Server was released. I've experienced no issues thus far.

## Description
<!-- Describe your changes in detail -->
Use Ubuntu 20.04 instead of Ubuntu 18.04.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
1. Spin up a new Docker container using the updated Dockerfile.
2. Confirm container is running Ubuntu 20.04 - `cat /etc/issue`.
3. Confirm functionalities of OpenVSCode Server works the same as container running Ubuntu 18.04.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
