### PR TITLE
Change test-web-integration.sh location

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run integration tests
         id: runIntegrationTests
         run: |
-          ./resources/server/test/test-web-integration.sh --browser chromium
+          ./scripts/test-web-integration.sh --browser chromium
 
       - name: Run smoke tests
         id: runSmokeTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           set -e
           VSCODE_REMOTE_SERVER_PATH="$GITHUB_WORKSPACE/vscode-reh-web-linux-${{ matrix.vscode_arch }}" \
-          ./resources/server/test/test-web-integration.sh --browser chromium
+          ./scripts/test-web-integration.sh --browser chromium
 
       - name: Run smoke tests
         if: matrix.vscode_arch == 'x64'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Location of test-web-integration.sh changed after upstream update

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
[Upstream commit](https://github.com/microsoft/vscode/commit/3640c1a425713e905f7898917cd15cc077204697)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
