### PR TITLE
update github workflows for release 1.68

### DIFF
--- a/.github/workflows/insiders-gp.yml
+++ b/.github/workflows/insiders-gp.yml
@@ -15,8 +15,8 @@ on:
 
 env:
   # Default values will be used by cron job
-  PARENT_COMMIT: ${{ github.event.inputs.parent_commit || 'upstream/main' }}
-  UPDATE_BRANCH: ${{ github.event.inputs.update_branch || 'gp-code/main' }}
+  PARENT_COMMIT: ${{ github.event.inputs.parent_commit || 'upstream/release/1.68' }}
+  UPDATE_BRANCH: ${{ github.event.inputs.update_branch || 'gp-code/release/1.68' }}
 
 jobs:
   sync-gp-code:

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -15,8 +15,8 @@ on:
 
 env:
   # Default values will be used by cron job
-  PARENT_COMMIT: ${{ github.event.inputs.parent_commit || 'upstream/main' }}
-  UPDATE_BRANCH: ${{ github.event.inputs.update_branch || 'main' }}
+  PARENT_COMMIT: ${{ github.event.inputs.parent_commit || 'upstream/release/1.68' }}
+  UPDATE_BRANCH: ${{ github.event.inputs.update_branch || 'release/1.68' }}
 
 jobs:
   sync-main:


### PR DESCRIPTION
## Description
Point code nightly to gp-code/release/1.68 branch

## Related Issue(s)
https://github.com/gitpod-io/gitpod/issues/10487

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
