### PR TITLE
feat: update base image to buildpack-deps:22.04-curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:20.04-curl
+FROM buildpack-deps:22.04-curl
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \


### PR DESCRIPTION
## Description
Updates the `Dockerfile` base image for this repo to `buildpack-deps:22.04-curl`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/openvscode-server/issues/377

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```