### PR TITLE
Bug: Release download URL fix (#553)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /home/
 
 ARG RELEASE_TAG
+ARG RELEASE_TYPE="stable" # Supports stable or insiders
 ARG RELEASE_ORG="gitpod-io"
 ARG OPENVSCODE_SERVER_ROOT="/home/.openvscode-server"
 
@@ -26,11 +27,16 @@ RUN if [ -z "${RELEASE_TAG}" ]; then \
     elif [ "${arch}" = "armv7l" ]; then \
         arch="armhf"; \
     fi && \
-    wget https://github.com/${RELEASE_ORG}/openvscode-server/releases/download/${RELEASE_TAG}/${RELEASE_TAG}-linux-${arch}.tar.gz && \
-    tar -xzf ${RELEASE_TAG}-linux-${arch}.tar.gz && \
-    mv -f ${RELEASE_TAG}-linux-${arch} ${OPENVSCODE_SERVER_ROOT} && \
+    if [ "${RELEASE_TYPE}" = "insiders" ]; then \
+        RELEASE_TYPE_SUFFIX="insiders-"; \
+    else \
+        RELEASE_TYPE_SUFFIX=""; \
+    fi && \
+    wget https://github.com/${RELEASE_ORG}/openvscode-server/releases/download/openvscode-server-${RELEASE_TYPE_SUFFIX}${RELEASE_TAG}/openvscode-server-${RELEASE_TYPE_SUFFIX}${RELEASE_TAG}-linux-${arch}.tar.gz && \
+    tar -xzf openvscode-server-${RELEASE_TYPE_SUFFIX}${RELEASE_TAG}-linux-${arch}.tar.gz && \
+    mv -f openvscode-server-${RELEASE_TYPE_SUFFIX}${RELEASE_TAG}-linux-${arch} ${OPENVSCODE_SERVER_ROOT} && \
     cp ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/openvscode-server ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/code && \
-    rm -f ${RELEASE_TAG}-linux-${arch}.tar.gz
+    rm -f openvscode-server-${RELEASE_TYPE_SUFFIX}${RELEASE_TAG}-linux-${arch}.tar.gz
 
 ARG USERNAME=openvscode-server
 ARG USER_UID=1000


### PR DESCRIPTION
## Description

 While building the docker image from `https://github.com/gitpod-io/openvscode-releases,` the github release url for downloading the release of openvscode-server is not properly getting parsed (wrong release name) and throwing `404` not found error from github. Like in the below image!

![1f355f1820cc02f6371b481760845d73](https://github.com/gitpod-io/openvscode-releases/assets/20869542/e50a54a3-b2ba-4dcd-9168-d6d3490174e2)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #553

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* No
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
