### PR TITLE
Fix regex in switch-branch.yml

### DIFF
--- a/.github/workflows/switch-branch.yml
+++ b/.github/workflows/switch-branch.yml
@@ -108,7 +108,7 @@ jobs:
 
             if (branchExists) {
                 replaceInFile('${{ github.workspace }}/gitpod/.github/workflows/code-nightly.yml', (object) =>
-                    object.replace(/https:\/\/api.github.com\/repos\/gitpod-io\/openvscode-server\/commits\/gp-code\/release\/.{1,5}/i, 'https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main'))
+                    object.replace(/https:\/\/api.github.com\/repos\/gitpod-io\/openvscode-server\/commits\/gp-code\/release\/\d{1,5}\.\d{1,5}/i, 'https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main'))
             } else {
                 replaceInFile('${{ github.workspace }}/gitpod/.github/workflows/code-nightly.yml', (object) =>
                     object.replace('https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main', `https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/release/${nextTag}`))


### PR DESCRIPTION
As reported by @mustard-mh [on Slack](https://gitpod.slack.com/archives/C032A46PWR0/p1720632253621619?thread_ts=1720629395.854819&cid=C032A46PWR0).

It makes sure to only include numbers and not the trailing `)`