### PR TITLE
Fix duplicate vscode layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,20 @@ ARG RELEASE_TAG
 ARG RELEASE_ORG="gitpod-io"
 ARG OPENVSCODE_SERVER_ROOT="/home/.openvscode-server"
 
+ARG USERNAME=openvscode-server
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Creating the user and usergroup
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USERNAME -m -s /bin/bash $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN chmod g+rw /home && \
+    mkdir -p /home/workspace && \
+    chown -R $USERNAME:$USERNAME /home/workspace
+
 # Downloading the latest VSC Server release and extracting the release archive
 # Rename `openvscode-server` cli tool to `code` for convenience
 RUN if [ -z "${RELEASE_TAG}" ]; then \
@@ -30,21 +44,7 @@ RUN if [ -z "${RELEASE_TAG}" ]; then \
     tar -xzf ${RELEASE_TAG}-linux-${arch}.tar.gz && \
     mv -f ${RELEASE_TAG}-linux-${arch} ${OPENVSCODE_SERVER_ROOT} && \
     cp ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/openvscode-server ${OPENVSCODE_SERVER_ROOT}/bin/remote-cli/code && \
-    rm -f ${RELEASE_TAG}-linux-${arch}.tar.gz
-
-ARG USERNAME=openvscode-server
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Creating the user and usergroup
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USERNAME -m -s /bin/bash $USERNAME \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
-
-RUN chmod g+rw /home && \
-    mkdir -p /home/workspace && \
-    chown -R $USERNAME:$USERNAME /home/workspace && \
+    rm -f ${RELEASE_TAG}-linux-${arch}.tar.gz && \
     chown -R $USERNAME:$USERNAME ${OPENVSCODE_SERVER_ROOT}
 
 USER $USERNAME


### PR DESCRIPTION
chown the openvscode directory in the same layer as it's extracted

## Description
vscode was being untarred in one layer, then in another layer every vscode file had its permissions changed causing every file to be written out to that layer too

You can see the layer sizes here https://hub.docker.com/layers/gitpod/openvscode-server/latest/images/sha256-236821ee7c8f9284b7f94799d4b66bc465926f435ac323af03e50bfb503c1ca1

/hold
